### PR TITLE
1.0.1 Default to empty string for repository URL

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -120,7 +120,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                     $warningList[] = sprintf(
                         '- Repository with URL "%s" contains a disallowed '.
                         'package type "%s". It\'s recommended to change this to "%s".',
-                        $repository['url'],
+                        $repository['url'] ?? '',
                         $repository['type'],
                         implode(
                             ', ',


### PR DESCRIPTION
Not all composer repository types have an URL. By defaulting to an
empty string a notice "Undefined index: url" is prevented.